### PR TITLE
Cooldown command & data caching

### DIFF
--- a/jojoepinger.py
+++ b/jojoepinger.py
@@ -106,6 +106,8 @@ def get_random_player_name():
     return get_player_identifiers(roll_player.random_player())
 
 
+# TODO: this doesnt all need to be cached since cards only use some of the data
+@cached(TTLCache(ttl=86400, maxsize=2000))
 def stats_from_name(name):
     data = query_api(
         PACEMAN_STATS_API,

--- a/jojoepinger.py
+++ b/jojoepinger.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import requests
 import redis
 import discord
+from cachetools import cached, TTLCache
 import roll_player
 from cards import Card
 
@@ -131,6 +132,7 @@ def get_player_pb(uuid_to_find):
     return player_pb
 
 
+@cached(TTLCache(ttl=86400, maxsize=2000))
 def get_player_identifiers(uuid_or_name):
     response = query_api(PLAYER_DB_API, "player", "minecraft", uuid_or_name)
     if response.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -74,13 +74,15 @@ def cooldown_command(interaction):
     rolls_message = "All 10 rolls are available."
     claims_message = "All 3 claims are available."
     if r.exists(rolls_key):
+        rolls = r.get(rolls_key)
         time_left = r.ttl(rolls_key)
         timestamp = floor(time() + int(time_left))
-        rolls_message = f"Your 10 rolls are available in <t:{timestamp}:R>"
+        rolls_message = f"You have {10-int(rolls)} rolls available & all 10 reset in <t:{timestamp}:R>"
     if r.exists(claims_key):
+        claims = r.get(claims_key)
         time_left = r.ttl(claims_key)
         timestamp = floor(time() + int(time_left))
-        claims_message = f"Your 3 claims are available in <t:{timestamp}:R>"
+        claims_message = f"You have {3-int(claims)} claims available & all 3 reset in <t:{timestamp}:R>"
     em = discord.Embed(title="Cooldowns", color=0)
     em.add_field(name="Rolls", value=rolls_message, inline=False)
     em.add_field(name="Claims", value=claims_message, inline=False)

--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ def cooldown_command(interaction):
     em.add_field(name="Claims", value=claims_message, inline=False)
     return em
 
+
 @bot.command(name="roll")
 async def roll(ctx):
     em, view = roll_command(interaction=ctx)

--- a/main.py
+++ b/main.py
@@ -56,6 +56,36 @@ async def ping(ctx):
     await ctx.send("pong")
 
 
+@bot.command(name="cooldown")
+async def cooldown(ctx):
+    em = cooldown_command(interaction=ctx)
+    await ctx.send(embed=em)
+
+
+@bot.tree.command(name="cooldown")
+async def cooldown_tree(interaction: discord.Interaction):
+    em = cooldown_command(interaction=interaction)
+    await interaction.response.send_message(embed=em)
+
+
+def cooldown_command(interaction):
+    rolls_key = f"_u{interaction.author.id}_s{interaction.guild.id}_rolls"
+    claims_key = f"_u{interaction.author.id}_s{interaction.guild.id}_claims"
+    rolls_message = "All 10 rolls are available."
+    claims_message = "All 3 claims are available."
+    if r.exists(rolls_key):
+        time_left = r.ttl(rolls_key)
+        timestamp = floor(time() + int(time_left))
+        rolls_message = f"Your 10 rolls are available in <t:{timestamp}:R>"
+    if r.exists(claims_key):
+        time_left = r.ttl(claims_key)
+        timestamp = floor(time() + int(time_left))
+        claims_message = f"Your 3 claims are available in <t:{timestamp}:R>"
+    em = discord.Embed(title="Cooldowns", color=0)
+    em.add_field(name="Rolls", value=rolls_message, inline=False)
+    em.add_field(name="Claims", value=claims_message, inline=False)
+    return em
+
 @bot.command(name="roll")
 async def roll(ctx):
     em, view = roll_command(interaction=ctx)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import logging
-from time import gmtime
-from time import strftime
+from time import gmtime, strftime, time
 import random
+from math import floor
 from functools import partial
 
 import redis
@@ -76,9 +76,9 @@ def roll_command(interaction):  # ROLL COMMAND
     rolls = r.get(rolls_key)
     if rolls is not None and int(rolls) >= 10:
         time_left = r.ttl(rolls_key)
-        minutes, seconds = divmod(int(time_left), 60)
+        timestamp = floor(time() + int(time_left))
         em = discord.Embed(
-            description=f"You used all 10 of your rolls, check back in {minutes:02}:{seconds:02}",
+            description=f"You used all 10 of your rolls, check back in <t:{timestamp}:R>",
             color=0xE74C3C,
         )
         view = None
@@ -152,9 +152,9 @@ def roll_command(interaction):  # ROLL COMMAND
             claims = r.get(claims_key)
             if claims is not None and int(claims) >= 3:
                 time_left = r.ttl(claims_key)
-                minutes, seconds = divmod(int(time_left), 60)
+                timestamp = floor(time() + int(time_left))
                 em = discord.Embed(
-                    description=f"You used all 3 of your claims this hour, check back in {minutes:02}:{seconds:02}",
+                    description=f"You used all 3 of your claims this hour, check back in <t:{timestamp}:R>",
                     color=0xE74C3C,
                 )
                 await interaction.response.send_message(embed=em)


### PR DESCRIPTION
Adds a ``cooldown`` command to let users check the roll and claim cooldowns, makes cooldowns both from the command and the warning use relative timestamps, and caches playerdb data & paceman stats for up to a day